### PR TITLE
Fix infinite recursion in top/bottom

### DIFF
--- a/src/Data/Ord/Down.purs
+++ b/src/Data/Ord/Down.purs
@@ -19,8 +19,8 @@ instance ordDown :: Ord a => Ord (Down a) where
   compare (Down x) (Down y) = invert (compare x y)
 
 instance boundedDown :: Bounded a => Bounded (Down a) where
-  top = bottom
-  bottom = top
+  top = Down bottom
+  bottom = Down top
 
 instance showDown :: Show a => Show (Down a) where
   show (Down a) = "(Down " <> show a <> ")"

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -53,6 +53,10 @@ main = do
   assertEq (f2 5)    true
   assertEq (f2 15)   false
 
+  log "top/bottom"
+  assertEq (fromDown (top :: Down Int)) (bottom :: Int)
+  assertEq (fromDown (bottom :: Down Int)) (top :: Int)
+
 associativityOf
   :: forall a
    . (Semigroup a, Eq a, Show a)
@@ -83,3 +87,6 @@ orderings2 = Tuple <$> orderings <*> orderings
 
 orderings3 :: Array (Tuple3 Ordering Ordering Ordering)
 orderings3 = tuple3 <$> orderings <*> orderings <*> orderings
+
+fromDown :: forall a. Down a -> a
+fromDown (Down a) = a


### PR DESCRIPTION
This was actually caught by the C++ compiler (clang, `-Wall` `-Werror`) on the pure11 output, and I then confirmed the same issue on the javascript output. Kind of nice.